### PR TITLE
Update phoenix1-4.7.0_1.3.0 for CDH 5.12.1 compatibility 

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-assembly/src/build/components-minimal.xml
+++ b/phoenix-assembly/src/build/components-minimal.xml
@@ -39,7 +39,9 @@
       <outputDirectory>/</outputDirectory>
       <unpack>true</unpack>
       <includes>
+        <include>co.cask.tephra:tephra*</include>
         <include>org.apache.phoenix:phoenix-*</include>
+        <include>org.apache.twill:twill*</include>
         <include>org.iq80.snappy:snappy</include>
       </includes>
       <excludes>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -5,6 +5,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-core/src/main/java/org/apache/hadoop/hbase/ipc/PhoenixRpcScheduler.java
+++ b/phoenix-core/src/main/java/org/apache/hadoop/hbase/ipc/PhoenixRpcScheduler.java
@@ -106,6 +106,21 @@ public class PhoenixRpcScheduler extends RpcScheduler {
     }
 
     @Override
+    public int getReadQueueLength() {
+        return this.delegate.getReadQueueLength();
+    }
+
+    @Override
+    public int getScanQueueLength() {
+        return this.delegate.getScanQueueLength();
+    }
+
+    @Override
+    public int getWriteQueueLength() {
+        return this.delegate.getWriteQueueLength();
+    }
+
+    @Override
     public int getReplicationQueueLength() {
         return this.delegate.getReplicationQueueLength();
     }
@@ -113,6 +128,21 @@ public class PhoenixRpcScheduler extends RpcScheduler {
     @Override
     public int getActiveRpcHandlerCount() {
         return this.delegate.getActiveRpcHandlerCount() + this.indexCallExecutor.getActiveHandlerCount() + this.metadataCallExecutor.getActiveHandlerCount();
+    }
+
+    @Override
+    public int getActiveReadRpcHandlerCount() {
+        return this.delegate.getActiveReadRpcHandlerCount();
+    }
+
+    @Override
+    public int getActiveScanRpcHandlerCount() {
+        return this.delegate.getActiveScanRpcHandlerCount();
+    }
+
+    @Override
+    public int getActiveWriteRpcHandlerCount() {
+        return this.delegate.getActiveWriteRpcHandlerCount();
     }
 
     @VisibleForTesting

--- a/phoenix-core/src/main/java/org/apache/phoenix/execute/DelegateHTable.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/execute/DelegateHTable.java
@@ -46,6 +46,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.Service;
 import com.google.protobuf.ServiceException;
 
+@SuppressWarnings("deprecation")
 public class DelegateHTable implements HTableInterface {
     protected final HTableInterface delegate;
 
@@ -121,6 +122,28 @@ public class DelegateHTable implements HTableInterface {
     @Override
     public Result getRowOrBefore(byte[] row, byte[] family) throws IOException {
         return delegate.getRowOrBefore(row, family);
+    }
+
+    @Override
+    public int getOperationTimeout() {
+        return delegate.getOperationTimeout();
+    }
+
+    @Override
+    public void setOperationTimeout(int operationTimeout) {
+//        delegate.setOperationTimeout(operationTimeout);
+    	;
+    }
+
+    @Override
+    public int getRpcTimeout() {
+        return delegate.getRpcTimeout();
+    }
+
+    @Override
+    public void setRpcTimeout(int rpcTimeout) {
+//        delegate.setRpcTimeout(rpcTimeout);
+    	;
     }
 
     @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/IndexMemStore.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/IndexMemStore.java
@@ -302,11 +302,16 @@ public class IndexMemStore implements KeyValueStore {
       this.kvsetItRow = null;
     }
 
+    @Override
+    public long getScannerOrder() {
+        return this.getScannerOrder();
+    }
+
     /**
      * MemStoreScanner returns max value as sequence id because it will always have the latest data
      * among all files.
      */
-    @Override
+//    @Override
     public long getSequenceID() {
       return Long.MAX_VALUE;
     }

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/scanner/FilteredKeyValueScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/scanner/FilteredKeyValueScanner.java
@@ -119,8 +119,14 @@ public class FilteredKeyValueScanner implements KeyValueScanner {
     }
 
     @Override
+    public long getScannerOrder() {
+        return this.delegate.getScannerOrder();
+    }
+
+//    @Override
     public long getSequenceID() {
-        return this.delegate.getSequenceID();
+//        return this.delegate.getSequenceID();
+    	return 0L;
     }
 
     @Override

--- a/phoenix-flume/pom.xml
+++ b/phoenix-flume/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-flume</artifactId>
   <name>Phoenix - Flume</name>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -15,7 +15,8 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-                <version>4.7.0-clabs-phoenix1.3.0</version>
+        <version>4.7.0-clabs-phoenix1.3.0</version>
+        <relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>phoenix-pherf</artifactId>

--- a/phoenix-pig/pom.xml
+++ b/phoenix-pig/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-pig</artifactId>
   <name>Phoenix - Pig</name>

--- a/phoenix-server-client/pom.xml
+++ b/phoenix-server-client/pom.xml
@@ -5,6 +5,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-server-client</artifactId>
   <name>Phoenix Query Server Client</name>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -5,6 +5,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-server</artifactId>
   <name>Phoenix Query Server</name>

--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -29,6 +29,7 @@
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
     <version>4.7.0-clabs-phoenix1.3.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>phoenix-spark</artifactId>
   <name>Phoenix - Spark</name>

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -28,6 +28,7 @@
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
       <version>4.7.0-clabs-phoenix1.3.0</version>
+      <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.cloudera.cdh</groupId>
     <artifactId>phoenix-root</artifactId>
     <version>1.3.0</version>
-    <relativePath/>
+    <relativePath>phoenix-root.pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.phoenix</groupId>


### PR DESCRIPTION
and to match current [CLABS_PHOENIX 1.3 parcel for CDH 5.7](http://archive.cloudera.com/cloudera-labs/phoenix/parcels/1.3/).

- Version update and packaging tweaks in most pom.xml (e.g. add root dependency on com.cloudera.cdh phoenix-root.pom.xml, where global properties like CDH version no. can be propagated from)
- Minimal code update to phoenix-core classes for compatibility with 5.7~5.12 HBase API changes (e.g. [HBASE-15236](https://issues.apache.org/jira/browse/HBASE-15236), [HBASE-15645](https://issues.apache.org/jira/browse/HBASE-15645)/[15866](https://issues.apache.org/jira/browse/HBASE-15866), [HBASE-16561](https://issues.apache.org/jira/browse/HBASE-16561)).  Code tested with our Spark 1.6 Scala app, but **need to be reviewed**.

I created new branch cdh5-4.7.0_1.3.0 with my best understanding of project naming convention.  Am new to GitHub, so please help push the new branch to the base project if it passes review (instead of modifying phoenix1-4.7.0_1.3.0.
  